### PR TITLE
Fix pagination redirect SEO issue and broken Next navigation

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -408,8 +408,9 @@ func (a *App) getPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	// Consolidate first page to / so there is a single canonical homepage URL
-	if page == 0 || page == 1 {
+	// Page 0 is a duplicate of the homepage ("/"), so consolidate it to a
+	// single canonical URL with a 301. Page 1 and up are distinct list pages.
+	if page <= 0 {
 		http.Redirect(w, r, "/", http.StatusMovedPermanently)
 		return
 	}
@@ -439,18 +440,29 @@ func (a *App) servePosts(w http.ResponseWriter, r *http.Request, page int) {
 		} else {
 			pageTitle = fmt.Sprintf("Page %d | srelog.dev", page)
 		}
+		// Build pagination links. The previous link for page 1 points to "/"
+		// (the homepage) rather than "/page?p=0" so we never link to a URL
+		// that only 301-redirects, which Google flags as "Page with redirect".
+		prevURL := "/"
+		if page-1 >= 1 {
+			prevURL = fmt.Sprintf("/page?p=%d", page-1)
+		}
+		nextURL := fmt.Sprintf("/page?p=%d", page+1)
+
 		data := struct {
-			Posts      []model.Post
-			Header     headerData
-			IsNextPage bool
-			PrevPage   int
-			NextPage   int
+			Posts   []model.Post
+			Header  headerData
+			HasPrev bool
+			HasNext bool
+			PrevURL string
+			NextURL string
 		}{
 			posts,
 			headerData{IsAdmin: a.Sessions.IsAdmin(r), CanonicalURL: canonicalURL, Title: pageTitle},
+			page > 0,
 			isNextPage(page, model.CountPosts(a.DB)),
-			absolute(page - 1),
-			absolute(page + 1),
+			prevURL,
+			nextURL,
 		}
 		if err := a.Temp.ExecuteTemplate(w, "posts.gohtml", data); err != nil {
 			log.Println("Template execution error:", err)
@@ -885,13 +897,6 @@ func (a *App) deleteComment(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 		return
 	}
-}
-
-func absolute(i int) int {
-	if i <= 0 {
-		return 0
-	}
-	return i
 }
 
 func isNextPage(nextPage, totalPosts int) bool {

--- a/app/handlers_test.go
+++ b/app/handlers_test.go
@@ -213,14 +213,20 @@ func TestGetPageHandler(t *testing.T) {
 		expectedContent string
 	}{
 		{
-			name:           "Get page 1 redirects to /",
+			name:           "Get page 1 serves a distinct list page",
 			path:           "/page?p=1",
 			method:         http.MethodGet,
-			expectedStatus: http.StatusMovedPermanently,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			name:           "Get page 0 redirects to /",
 			path:           "/page?p=0",
+			method:         http.MethodGet,
+			expectedStatus: http.StatusMovedPermanently,
+		},
+		{
+			name:           "Get negative page redirects to /",
+			path:           "/page?p=-1",
 			method:         http.MethodGet,
 			expectedStatus: http.StatusMovedPermanently,
 		},
@@ -231,16 +237,16 @@ func TestGetPageHandler(t *testing.T) {
 			expectedStatus: http.StatusBadRequest,
 		},
 		{
-			name:           "HEAD request on p=1 redirects to /",
+			name:           "HEAD request on p=1 returns OK",
 			path:           "/page?p=1",
 			method:         http.MethodHead,
-			expectedStatus: http.StatusMovedPermanently,
+			expectedStatus: http.StatusOK,
 		},
 		{
-			name:           "POST request on p=1 redirects to /",
+			name:           "POST request on p=1 is not allowed",
 			path:           "/page?p=1",
 			method:         http.MethodPost,
-			expectedStatus: http.StatusMovedPermanently,
+			expectedStatus: http.StatusMethodNotAllowed,
 		},
 	}
 
@@ -1072,25 +1078,6 @@ func TestSecurityMiddleware(t *testing.T) {
 
 // Test utility functions
 func TestUtilityFunctions(t *testing.T) {
-	t.Run("absolute function", func(t *testing.T) {
-		tests := []struct {
-			input    int
-			expected int
-		}{
-			{5, 5},
-			{0, 0},
-			{-1, 0},
-			{-10, 0},
-		}
-
-		for _, tt := range tests {
-			result := absolute(tt.input)
-			if result != tt.expected {
-				t.Errorf("absolute(%d) = %d, expected %d", tt.input, result, tt.expected)
-			}
-		}
-	})
-
 	t.Run("isNextPage function", func(t *testing.T) {
 		tests := []struct {
 			nextPage   int

--- a/templates/posts.gohtml
+++ b/templates/posts.gohtml
@@ -16,8 +16,8 @@
 {{end}}
 	<div class="docs-section" style="margin:0px;padding:10px"></div>
 		<h5>
-			{{if and (eq .PrevPage 0) (eq .NextPage 1)}}<span style="color:#212222;">← Prev</span>{{else}}<a href="/page?p={{.PrevPage}}">← Prev</a>{{end}}
-			{{if .IsNextPage}}<a href="/page?p={{.NextPage}}">Next →</a>{{else}}<span style="color:#212222">Next →</span>{{end}}
+			{{if .HasPrev}}<a href="{{.PrevURL}}">← Prev</a>{{else}}<span style="color:#212222;">← Prev</span>{{end}}
+			{{if .HasNext}}<a href="{{.NextURL}}">Next →</a>{{else}}<span style="color:#212222">Next →</span>{{end}}
 		</h5>
 </div>
 


### PR DESCRIPTION
## Problem

Google Search Console flagged **`https://srelog.dev/page?p=0`** as "Page with redirect". The pagination "← Prev" link generated `/page?p=0`, which 301-redirects to `/`, so Google kept discovering the internal link and flagging the redirect.

While tracing this, I also found a regression from `863787a`: the condition `page == 0 || page == 1` was redirecting `/page?p=1` (the legitimate *second* page, offset 8) to `/`. Since the homepage's "Next →" points to `/page?p=1`, **Next navigation looped back to home and all posts beyond the first 8 were unreachable.**

> Note: the other flagged URL, `http://srelog.dev/`, is just the HTTP→HTTPS redirect — expected and correct, nothing to fix.

## Changes

- Point the "Prev" link to `/` (homepage) instead of `/page?p=0`, so no internal link ever targets a redirect-only URL.
- Only redirect `p <= 0` to `/` (p=0 duplicates the homepage); `p=1` and up now serve their real content, restoring Next navigation.
- Replace fragile `PrevPage`/`NextPage`/`IsNextPage` template fields with explicit `HasPrev`/`HasNext`/`PrevURL`/`NextURL` computed server-side.
- Remove the now-unused `absolute()` helper and update the affected tests.

## Verification

- `go build ./...` passes.
- `TestGetPageHandler`, `TestUtilityFunctions`, template, and navigation tests pass.
- Added an end-to-end check (20 seeded posts) confirming: homepage Next → `/page?p=1`, page 1 Prev → `/`, and **no `/page?p=0` link anywhere** in the rendered HTML.

After merge/deploy, click **VALIDATE FIX** in Search Console — the `/page?p=0` entry will clear as Google re-crawls and finds no links to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)